### PR TITLE
feat: add RFC1123 compliant check for username

### DIFF
--- a/admin/nuvfile.yml
+++ b/admin/nuvfile.yml
@@ -22,10 +22,10 @@ vars:
 env:
   KUBECONFIG:
     sh: |
-        if test -e $NUV_TMP/kubeconfig
-        then echo  $NUV_TMP/kubeconfig
-        else echo ~/.kube/config
-        fi  
+      if test -e $NUV_TMP/kubeconfig
+      then echo  $NUV_TMP/kubeconfig
+      else echo ~/.kube/config
+      fi
 
 tasks:
   adduser:
@@ -42,8 +42,19 @@ tasks:
         then 
           nuv -die "User name must be at least 5 chars long: $USERNAME"
         fi
-        username_match="$(nuv -validate -r '^api(\..*)?$' $USERNAME)"
+
         check_result="'$USERNAME' matches the regex."
+
+        # check {{._username_}} complies with lower case RFC 1123
+        username_match="$(nuv -validate -r '^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$' $USERNAME)"
+
+        if [ ! "$username_match" = "$check_result" ]; then
+          nuv -die "User name must consist of lower case characters separated by '-' (RFC 1123)"
+        fi
+
+        # check {{._username_}} is not api or api.*
+        username_match="$(nuv -validate -r '^api(\..*)?$' $USERNAME)"
+
         if [ "$username_match" = "$check_result" ]; then
           nuv -die "api and any api.* are reserved names."
         fi


### PR DESCRIPTION
When creating a new user, if the username given is invalid (it must be lower case RFC 1123) the system returns an error.

A compliant string should (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/):
-  contain at most 63 characters
- contain only lowercase alphanumeric characters or '-'
- start with an alphanumeric character
- end with an alphanumeric character

This PR adds a check with a regex for that.