### PR TITLE
fix update cli curl and align nuvroot

### DIFF
--- a/nuvroot.json
+++ b/nuvroot.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-dev.2308010904",
+  "version": "0.3.0-dev.2308011557",
   "config": {
     "nuvolaris": {
       "apihost": "auto",

--- a/update/nuvfile.yml
+++ b/update/nuvfile.yml
@@ -43,7 +43,7 @@ tasks:
         if test -e "$TGT"
         then rm "$TGT"
         fi
-        if curl -o "$TGT" "$SRC"
+        if curl -sL -o "$TGT" "$SRC"
         then
           #echo $FILE
           #echo {{.CMD}}


### PR DESCRIPTION
This PR updates the nuv build to 0.3.0-dev.2308011557 and adds -sL to the curl command to download the build