### PR TITLE
add osh cmd to apply acme-openshift

### DIFF
--- a/cloud/osh/acme-openshift/acme-rbac.yaml
+++ b/cloud/osh/acme-openshift/acme-rbac.yaml
@@ -1,0 +1,114 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: openshift-acme
+  namespace: default
+  labels:
+    app: openshift-acme
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-acme
+  labels:
+    app: openshift-acme
+rules:
+- apiGroups:
+  - "route.openshift.io"
+  resources:
+  - routes
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+  - deletecollection
+
+- apiGroups:
+  - "route.openshift.io"
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - services
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+
+- apiGroups:
+  - ""
+  resources:
+  - limitranges
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
+  - "apps"
+  resources:
+  - replicasets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-acme-crb
+  namespace: default
+  labels:
+    app: openshift-acme-crb
+subjects:
+- kind: ServiceAccount
+  name:  openshift-acme
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: openshift-acme
+  apiGroup: rbac.authorization.k8s.io

--- a/cloud/osh/acme-openshift/acme-setup.yaml
+++ b/cloud/osh/acme-openshift/acme-setup.yaml
@@ -1,0 +1,58 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: letsencrypt-live
+  namespace: default
+  annotations:
+    "acme.openshift.io/priority": "100"
+  labels:
+    managed-by: "openshift-acme"
+    type: "CertIssuer"
+data:
+  "cert-issuer.types.acme.openshift.io": '{"type":"ACME","acmeCertIssuer":{"directoryUrl":"https://acme-v02.api.letsencrypt.org/directory"}}'
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: openshift-acme
+  namespace: default
+  labels:
+    app: openshift-acme
+  annotations:
+spec:
+  selector:
+    matchLabels:
+      app: openshift-acme
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: openshift-acme
+    spec:
+      serviceAccountName: openshift-acme
+      containers:
+      - name: openshift-acme
+        image: quay.io/tnozicka/openshift-acme:controller
+        imagePullPolicy: Always
+        args:
+        - --exposer-image=quay.io/tnozicka/openshift-acme:exposer
+        - --loglevel=4

--- a/cloud/osh/nuvfile.yml
+++ b/cloud/osh/nuvfile.yml
@@ -74,3 +74,8 @@ tasks:
       - task: prereq
       - task: copy
       - task: apihost
+
+  setup:
+    desc: setup openshift cluster with acme-openshift
+    cmds:
+      - kubectl apply -f acme-openshift

--- a/cloud/osh/nuvopts.txt
+++ b/cloud/osh/nuvopts.txt
@@ -1,5 +1,6 @@
-Importing OpenShift configuration
+OpenShift configuration
 
 Usage:
     osh import <kubeconfig>
     osh test <kubeconfig>
+    osh setup


### PR DESCRIPTION
This PR adds `nuv cloud osh setup` command that applies the manifest files for acme-openshift