### PR TITLE
Several fixes for windows compatibility

### DIFF
--- a/cloud/k3s/nuvfile.yml
+++ b/cloud/k3s/nuvfile.yml
@@ -15,25 +15,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3'
+version: "3"
 
 vars:
-  SSH: "/usr/bin/ssh -oStrictHostKeyChecking=no"
+  SSH: "ssh -oStrictHostKeyChecking=no"
   CERTMANAGER: "https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml"
 
 env:
-  KUBECONFIG: 
-    sh: |- 
-        if test -e "$NUV_TMP/kubeconfig"
-        then echo "$NUV_TMP/kubeconfig"
-        else echo ~/.kube/config
-        fi
+  KUBECONFIG:
+    sh: |-
+      if test -e "$NUV_TMP/kubeconfig"
+      then echo "$NUV_TMP/kubeconfig"
+      else echo ~/.kube/config
+      fi
 
 tasks:
-
   get-cert-manager:
     cmds:
-    - curl -L "{{.CERTMANAGER}}" >cert-manager.yaml
+      - curl -L "{{.CERTMANAGER}}" >cert-manager.yaml
 
   install:
     silent: true
@@ -46,7 +45,7 @@ tasks:
         --local-path=$NUV_TMP/kubeconfig
     vars:
       USERNAME: '{{.USERNAME | default "root"}}'
-  
+
   cert-manager:
     silent: true
     #desc: install cert-manager
@@ -57,50 +56,49 @@ tasks:
     silent: true
     desc: create a k3s with ssh in SERVER=<server> using USERNAME=<user> with sudo
     cmds:
-    - config NUVOLARIS_KUBE=k3s
-    - task: install
-    - task: cert-manager
-    - cp "$NUV_TMP/kubeconfig" "$NUV_TMP/ks3-{{.SERVER}}.kubeconfig"
-  
+      - config NUVOLARIS_KUBE=k3s
+      - task: install
+      - task: cert-manager
+      - cp "$NUV_TMP/kubeconfig" "$NUV_TMP/ks3-{{.SERVER}}.kubeconfig"
+
   delete:
     silent: true
     desc: uninstall with ssh in SERVER=<server> using USER=<user> with sudo
     cmds:
-    - test -n "{{.SERVER}}" || die "please use SERVER="
-    - "{{.SSH}} '{{.USERNAME}}@{{.SERVER}}' sudo /usr/local/bin/k3s-uninstall.sh"
-    - rm "$NUV_TMP/kubeconfig" "$NUV_TMP/ks3-{{.SERVER}}.kubeconfig"
+      - test -n "{{.SERVER}}" || die "please use SERVER="
+      - "{{.SSH}} '{{.USERNAME}}@{{.SERVER}}' sudo /usr/local/bin/k3s-uninstall.sh"
+      - rm "$NUV_TMP/kubeconfig" "$NUV_TMP/ks3-{{.SERVER}}.kubeconfig"
     vars:
       USERNAME: '{{.USERNAME | default "root"}}'
-  
+
   status:
     desc: status of the server
     silent: true
     cmds:
-    - |
-      if test -e $NUV_TMP/kubeconfig
-      then {{.RUN}} kubectl get nodes
-      else echo "No Cluster Installed"
-      fi
+      - |
+        if test -e $NUV_TMP/kubeconfig
+        then {{.RUN}} kubectl get nodes
+        else echo "No Cluster Installed"
+        fi
 
   info:
     silent: true
     desc: info on the server
     cmds:
-    - echo KUBECONFIG="$KUBECONFIG"
-    - echo SERVER_HOST="$SERVER_HOST"
-    - echo SERVER_USERNAME="$SERVER_USERNAME"
-  
+      - echo KUBECONFIG="$KUBECONFIG"
+      - echo SERVER_HOST="$SERVER_HOST"
+      - echo SERVER_USERNAME="$SERVER_USERNAME"
+
   kubeconfig:
     desc: recover the kubeconfig from a server with k3s
     cmds:
-    - task: prereq
-    - test -n "{{.SERVER}}" || die "please use SERVER="
-    - >
-      {{.SSH}} '{{.USERNAME}}@{{.SERVER}}' 
-      sudo cat /etc/rancher/k3s/k3s.yaml 
-      | replace --stdin -s '127.0.0.1' -r '{{.SERVER}}'
-      >"$NUV_TMP/kubeconfig"
-    - cp "$NUV_TMP/kubeconfig" "$NUV_TMP/ks3-{{.SERVER}}.kubeconfig"
+      - task: prereq
+      - test -n "{{.SERVER}}" || die "please use SERVER="
+      - >
+        {{.SSH}} '{{.USERNAME}}@{{.SERVER}}' 
+        sudo cat /etc/rancher/k3s/k3s.yaml 
+        | replace --stdin -s '127.0.0.1' -r '{{.SERVER}}'
+        >"$NUV_TMP/kubeconfig"
+      - cp "$NUV_TMP/kubeconfig" "$NUV_TMP/ks3-{{.SERVER}}.kubeconfig"
     vars:
       USERNAME: '{{.USERNAME | default "root"}}'
-

--- a/cloud/mk8s/nuvfile.yml
+++ b/cloud/mk8s/nuvfile.yml
@@ -22,8 +22,8 @@ vars:
 env:
   KUBECONFIG:
     sh: |-
-      if test -e "$NUV_TMP/kubeconfig"
-      then echo "$NUV_TMP/kubeconfig"
+      if test -e $(realpath "$NUV_TMP/kubeconfig")
+      then echo $(realpath "$NUV_TMP/kubeconfig")
       else echo ~/.kube/config
       fi
 
@@ -98,7 +98,7 @@ tasks:
       - >
         {{.SSH}} '{{.USERNAME}}@{{.SERVER}}' 
         sudo microk8s config      
-        | awk '/server:/ {$2="https://{{.SERVER}}:16443"} 1'
+        | awk '/server:/ {$0="  server: https://{{.SERVER}}:16443"} 1'
         >"$NUV_TMP/kubeconfig"
       - cp "$NUV_TMP/kubeconfig" "$NUV_TMP/mk8s-{{.SERVER}}.kubeconfig"
     vars:

--- a/cloud/mk8s/nuvfile.yml
+++ b/cloud/mk8s/nuvfile.yml
@@ -98,7 +98,7 @@ tasks:
       - >
         {{.SSH}} '{{.USERNAME}}@{{.SERVER}}' 
         sudo microk8s config      
-        | sed -e "s!server: .*!server: https://{{.SERVER}}:16443!"
+        | awk '/server:/ {$2="https://{{.SERVER}}:16443"} 1'
         >"$NUV_TMP/kubeconfig"
       - cp "$NUV_TMP/kubeconfig" "$NUV_TMP/mk8s-{{.SERVER}}.kubeconfig"
     vars:

--- a/cloud/mk8s/nuvfile.yml
+++ b/cloud/mk8s/nuvfile.yml
@@ -14,21 +14,20 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-version: '3'
+version: "3"
 
 vars:
-  SSH: "/usr/bin/ssh -oStrictHostKeyChecking=no"
+  SSH: "ssh -oStrictHostKeyChecking=no"
 
 env:
-  KUBECONFIG: 
-    sh: |- 
-        if test -e "$NUV_TMP/kubeconfig"
-        then echo "$NUV_TMP/kubeconfig"
-        else echo ~/.kube/config
-        fi
+  KUBECONFIG:
+    sh: |-
+      if test -e "$NUV_TMP/kubeconfig"
+      then echo "$NUV_TMP/kubeconfig"
+      else echo ~/.kube/config
+      fi
 
 tasks:
-
   prereq:
     silent: true
     cmds:
@@ -40,7 +39,7 @@ tasks:
       - "{{.SSH}} -V 2>/dev/null || die 'you need an ssh client in your PATH'"
       - config AWS_PREREQ_OK="true"
     status:
-    - config AWS_PREREQ_OK
+      - config AWS_PREREQ_OK
 
   install:
     silent: true
@@ -53,54 +52,54 @@ tasks:
       - "{{.SSH}} {{.USERNAME}}@{{.SERVER}} sudo bash mk8s.sh"
     vars:
       USERNAME: '{{.USERNAME | default "root"}}'
-  
+
   create:
     silent: true
     desc: create a mk8s with ssh in SERVER=<server> using USERNAME=<user> with sudo
     cmds:
-    - config NUVOLARIS_KUBE=microk8s
-    - task: install
-    - task: kubeconfig
-  
+      - config NUVOLARIS_KUBE=microk8s
+      - task: install
+      - task: kubeconfig
+
   delete:
     silent: true
     desc: uninstall microk8s with ssh in SERVER=<server> using USERNAME=<user> with sudo
     cmds:
-    - test -n "{{.SERVER}}" || die "please use SERVER="
-    - "{{.SSH}} {{.USERNAME}}@{{.SERVER}} sudo snap remove microk8s"
-    - rm "$NUV_TMP/kubeconfig" "$NUV_TMP/mk8s-{{.SERVER}}.kubeconfig"
+      - test -n "{{.SERVER}}" || die "please use SERVER="
+      - "{{.SSH}} {{.USERNAME}}@{{.SERVER}} sudo snap remove microk8s"
+      - rm "$NUV_TMP/kubeconfig" "$NUV_TMP/mk8s-{{.SERVER}}.kubeconfig"
     vars:
       USERNAME: '{{.USERNAME | default "root"}}'
-        
+
   status:
     desc: status of the server
     silent: true
     cmds:
-    - |
-      if test -e $NUV_TMP/kubeconfig
-      then {{.RUN}} kubectl get nodes
-      else echo "No Cluster Installed"
-      fi
+      - |
+        if test -e $NUV_TMP/kubeconfig
+        then {{.RUN}} kubectl get nodes
+        else echo "No Cluster Installed"
+        fi
 
   info:
     silent: true
     desc: info on the server
     cmds:
-    - echo KUBECONFIG="$KUBECONFIG"
-    - echo SERVER_HOST="$SERVER_HOST"
-    - echo SERVER_USERNNAME="$SERVER_USERNAME"
-  
+      - echo KUBECONFIG="$KUBECONFIG"
+      - echo SERVER_HOST="$SERVER_HOST"
+      - echo SERVER_USERNNAME="$SERVER_USERNAME"
+
   kubeconfig:
     silent: true
     desc: recover the kubeconfig from a server with microk8s
     cmds:
-    - task: prereq
-    - test -n "{{.SERVER}}" || die "please use SERVER="
-    - >
-      {{.SSH}} '{{.USERNAME}}@{{.SERVER}}' 
-      sudo microk8s config      
-      | sed -e "s!server: .*!server: https://{{.SERVER}}:16443!"
-      >"$NUV_TMP/kubeconfig"
-    - cp "$NUV_TMP/kubeconfig" "$NUV_TMP/mk8s-{{.SERVER}}.kubeconfig"
+      - task: prereq
+      - test -n "{{.SERVER}}" || die "please use SERVER="
+      - >
+        {{.SSH}} '{{.USERNAME}}@{{.SERVER}}' 
+        sudo microk8s config      
+        | sed -e "s!server: .*!server: https://{{.SERVER}}:16443!"
+        >"$NUV_TMP/kubeconfig"
+      - cp "$NUV_TMP/kubeconfig" "$NUV_TMP/mk8s-{{.SERVER}}.kubeconfig"
     vars:
       USERNAME: '{{.USERNAME | default "root"}}'

--- a/setup/kubernetes/nuvfile.yml
+++ b/setup/kubernetes/nuvfile.yml
@@ -30,8 +30,8 @@ vars:
 env:
   KUBECONFIG:
     sh: |
-      if test -e $NUV_TMP/kubeconfig
-      then echo  $NUV_TMP/kubeconfig
+      if test -e $(realpath "$NUV_TMP/kubeconfig")
+      then echo $(realpath "$NUV_TMP/kubeconfig")
       else echo ~/.kube/config
       fi
 
@@ -101,25 +101,25 @@ tasks:
   runtimes:
     silent: true
     cmds:
-    - |-
-      cat <<EOF >_runtimes.yaml
-      apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: openwhisk-runtimes
-        namespace: nuvolaris
-      data:
-        runtimes.json: |-
-      EOF
-    - awk '{ print "        " $0}' <"{{.RUNTIMES}}" >>_runtimes.yaml
-    - kubectl -n nuvolaris apply -f _runtimes.yaml
+      - |-
+        cat <<EOF >_runtimes.yaml
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: openwhisk-runtimes
+          namespace: nuvolaris
+        data:
+          runtimes.json: |-
+        EOF
+      - awk '{ print "        " $0}' <"{{.RUNTIMES}}" >>_runtimes.yaml
+      - kubectl -n nuvolaris apply -f _runtimes.yaml
     vars:
-      RUNTIMES: 
+      RUNTIMES:
         sh: |
-            if test -e "$NUV_TMP/runtimes.json"
-            then echo "$NUV_TMP/runtimes.json"
-            else echo "runtimes.json"
-            fi
+          if test -e "$NUV_TMP/runtimes.json"
+          then echo "$NUV_TMP/runtimes.json"
+          else echo "runtimes.json"
+          fi
 
   prepare:
     #desc: prepare the environment
@@ -220,7 +220,7 @@ tasks:
       - "{{.RUN}} kubectl -n nuvolaris delete wsku --all"
       - "{{.RUN}} kubectl -n nuvolaris delete wsk/controller"
       - "{{.RUN}} kubectl -n nuvolaris delete all --all"
-      - "{{.RUN}} kubectl -n nuvolaris delete pvc --all"     
+      - "{{.RUN}} kubectl -n nuvolaris delete pvc --all"
       - "{{.RUN}} kubectl -n nuvolaris delete ing --all --grace-period=0"
       - "{{.RUN}} kubectl -n nuvolaris delete kubegres --all"
       - "{{.RUN}} kubectl -n nuvolaris delete cm/config --grace-period=0"
@@ -232,7 +232,6 @@ tasks:
     silent: true
     desc: "unlock locked deletion (removing a finalizers)"
     cmds:
-    - >
-      kubectl -n nuvolaris patch wsk/controller --type=merge 
-      --patch '{"metadata": {"finalizers":[] } }'
-
+      - >
+        kubectl -n nuvolaris patch wsk/controller --type=merge 
+        --patch '{"metadata": {"finalizers":[] } }'


### PR DESCRIPTION
This PR changes small things to make it more compatible with windows. It removes a `sed` command usage as it is not available on windows and it uses awk which is embedded in nuv. 
It removes in k3s and mk8s the entire path /usr/bin/ssh in the SSH variable to just have `ssh` so it will work on windows too.