### PR TITLE
feat: add devel apihost/user to get host and user

### DIFF
--- a/devel/nuvfile.yml
+++ b/devel/nuvfile.yml
@@ -18,6 +18,18 @@
 version: "3"
 
 tasks:
+  user:
+    silent: true
+    desc: get user
+    cmds:
+      - wsk property get | awk '/whisk namespace/{print $3}'
+
+  apihost:
+    silent: true
+    desc: get apihost
+    cmds:
+      - wsk property get | awk '/whisk API host/{print $4}'
+
   detect:
     silent: true
     desc: detect project in directory

--- a/devel/nuvopts.txt
+++ b/devel/nuvopts.txt
@@ -6,11 +6,15 @@ Usage:
   devel detect [<path>]
   devel scan [<path>] [--force]
   devel deploy [<repo_or_path>]
+  devel apihost
+  devel user
 
 Commands:
   detect    Detect if in a directory there is a web and/or packages folders.
   scan      Scan a project directory and generate a manifest file.
   deploy    Deploy a project from a directory or from a git repository.
+  apihost   Print the API host URL of the latest deployment.
+  user      Print the current user name of the latest deployment.
 
 Options:
 


### PR DESCRIPTION
This PR adds `nuv devel apihost` and `nuv devel user` to have commands to grab the current apihost and user of a deployment.