### PR TITLE
feat: add util check-operator-version

### DIFF
--- a/util/nuvfile.yml
+++ b/util/nuvfile.yml
@@ -89,3 +89,11 @@ tasks:
 
   testbed:
     - echo $(realpath $GCLOUD_SSHKEY)
+
+  check-operator-version:
+    silent: true
+    cmds:
+      - |
+        output=$(nuv debug operator:version)
+        tag=$(echo $output | awk -F: '{print $2}')
+        needupdate {{._version_}} $tag

--- a/util/nuvopts.txt
+++ b/util/nuvopts.txt
@@ -11,6 +11,7 @@ Usage:
   util realpath <file>
   util notify <message>
   util testbed
+  util check-operator-version <version>
   
 Commands:
   util secrets              generate system secrets 


### PR DESCRIPTION
This PR adds an utility subcommand to check if the current operator version is greater than a given version. This will be used in nuv to check the operator version when updating.