### PR TITLE
feat: add docker precondition in devcluster

### DIFF
--- a/setup/nuvfile.yml
+++ b/setup/nuvfile.yml
@@ -22,9 +22,11 @@ vars:
   ARCH: '{{ARCH}}'
 
 tasks:
-  
   devcluster:
     silent: true
+    preconditions:
+      - sh: docker info 
+        msg: "You need to install docker before running this command."
     cmds:
     - |
       if {{.__status}}


### PR DESCRIPTION
This PR closes https://github.com/nuvolaris/nuvolaris-bugs/issues/16

It uses a new feature in task `precondition` to implement the pre flight check for docker when using `nuv setup devcluster`