### PR TITLE
Add update runtimes command

### DIFF
--- a/update/nuvfile.yml
+++ b/update/nuvfile.yml
@@ -133,3 +133,8 @@ tasks:
     desc: deploys latest version of operator
     cmds:
       - nuv setup kubernetes operator-update
+
+  runtimes:
+    desc: deploys latest version of runtimes
+    cmds:
+      - nuv setup kubernetes runtimes


### PR DESCRIPTION
This PR adds the command `nuv update runtimes` so the runtimes can be updated independently in a nuvolaris installation.