### PR TITLE
Accept '-' in usernames when creating user

### DIFF
--- a/admin/nuvfile.yml
+++ b/admin/nuvfile.yml
@@ -55,7 +55,7 @@ tasks:
         fi
 
         # check {{._username_}} complies with lower case RFC 1123
-        validate -r '^[a-z0-9](?:[a-z0-9]{0,61}[a-z0-9])?$' $USERNAME "User name must consist of only lower case characters (max 61 chars)"
+        validate -r '^[a-z0-9][a-z0-9-]{0,59}[a-z0-9]$' $USERNAME "User name can only contain lower case characters and '-' (max 61 chars)"
 
         # check {{._username_}} is not api or api.*
         # This cannot happen as the minimum length is 5 chars and the dot would fail the previous check

--- a/devel/nuvfile.yml
+++ b/devel/nuvfile.yml
@@ -32,7 +32,7 @@ tasks:
 
   detect:
     silent: true
-    desc: detect project in directory
+    desc: detect project in folders
     env:
       PACKAGES_PATH:
         sh: |
@@ -52,23 +52,23 @@ tasks:
     cmds:
       - |
         if [ -d "$PACKAGES_PATH" ] && [ -d "$WEB_PATH" ]; then
-          echo "Packages and web directory present."  
+          echo "Packages and web present."  
           exit 0
         fi
 
         if [ ! -d "$PACKAGES_PATH" ]; then
-          echo "No project detected (missing packages directory)."
+          echo "No project detected (missing packages folder)."
           exit 1
         fi
         if [ ! -d "$WEB_PATH" ]; then
-          echo "Project detected: packages directory found."
+          echo "Project detected: packages folder found."
           exit 0
         fi
-        die "No project detected (missing packages and web directory)."
+        die "No project detected (missing packages and web folder)."
 
   scan:
     silent: true
-    desc: scan directory and generate nuvolaris manifest files
+    desc: scan projects and generate nuvolaris manifest files
     cmds:
       - task: detect
       - |
@@ -93,6 +93,8 @@ tasks:
             P=$(realpath {{._path_}})
           fi
           echo $P
+      NUV_APIHOST:
+        sh: nuv devel apihost
 
   deploy:
     silent: true

--- a/devel/scanner.js
+++ b/devel/scanner.js
@@ -64,23 +64,17 @@ function main() {
     let path = process.argv[2];
 
     let manifest = scanPackages(path);
-
     manifest = scanEnv(manifest);
 
     let manifestYaml = nuv.toYaml(manifest);
-
     const manifestPath = nuv.joinPath(process.env.NUV_TMP, "manifest.yaml");
-
     nuv.writeFile(manifestPath, manifestYaml);
     console.log("Manifest file generated.");
 }
 
 function scanEnv(manifest) {
     console.log('Adding secrets...');
-
     let config = nuv.nuvExec('nuv', '-config', '-d');
-
-
     const lines = config.split('\n');
     lines.forEach(function (line) {
         const parts = line.split('=');
@@ -89,7 +83,6 @@ function scanEnv(manifest) {
             if (!key.startsWith('SECRET_')) {
                 return;
             }
-
             for (const packageName in manifest.packages) {
                 if (!manifest.packages[packageName].inputs) {
                     manifest.packages[packageName].inputs = {};


### PR DESCRIPTION
This PR fixes the regex used to check the validity of a username when doing `nuv admin adduser` to allow '-' in usernames.